### PR TITLE
#5 $Healthを現在のScoreToHealthと同じにする処理を追加

### DIFF
--- a/data/score_damage/functions/core/get_status.mcfunction
+++ b/data/score_damage/functions/core/get_status.mcfunction
@@ -6,6 +6,9 @@
 
 # HP
     execute store result score $Health ScoreDamageCore run data get entity @s Health 10000
+    # ScoreToHealthがある場合それがHP
+        execute if score @s ScoreToHealth matches -2147483648.. run scoreboard players operation $Health ScoreDamageCore = @s ScoreToHealth
+        execute if score @s ScoreToHealth matches -2147483648.. run scoreboard players operation $Health ScoreDamageCore *= $100 ScoreDamageCore
 # 防御力
     execute if data storage score_damage: Argument{BypassArmor:0b} store result score $DefensePoints ScoreDamageCore run attribute @s generic.armor get 100
     execute if data storage score_damage: Argument{BypassArmor:1b} run scoreboard players set $DefensePoints ScoreDamageCore 0


### PR DESCRIPTION
# 修正内容
2行追加して、`$Health`とScoreToHealthの値を同じにするようにした。
`$Health`の倍率は10000倍なのに対して、ScoreToHealthの倍率は100倍なので`$100`をかけて合わせた。

# 動作確認
11ダメージをtick中に2度実行したとき、死亡するようになった。
6ダメージと4ダメージで10ダメージのとき、体力が10になった。

---

Issue参照用(#5)